### PR TITLE
Fix module imports and how to access IOBluetooth references

### DIFF
--- a/bluetooth/macos/__init__.py
+++ b/bluetooth/macos/__init__.py
@@ -1,4 +1,4 @@
-import bluetooth.macos.discovery as discovery
+from bluetooth.macos import discovery as discovery
 #from bluetooth.macos.btsocket import BluetoothSocket
 
 from bluetooth.btcommon import *

--- a/bluetooth/macos/discovery.py
+++ b/bluetooth/macos/discovery.py
@@ -3,7 +3,8 @@ import time
 import logging
 
 import objc
-from Foundation import NSObject, IOBluetoothDeviceInquiry
+from Foundation import NSObject
+from . import IOBluetooth
 
 from bluetooth.device import Device
 from bluetooth.macos.loop import Loop
@@ -52,7 +53,7 @@ class DeviceInquiryDelegate(NSObject):
     # NSObject init
     def init(self, create_loop=True):
         self = super().init()
-        self._inquiry = IOBluetoothDeviceInquiry.inquiryWithDelegate_(self)
+        self._inquiry = IOBluetooth.IOBluetoothDeviceInquiry.inquiryWithDelegate_(self)
         self.set_updatenames(False)
 
         self.running = False


### PR DESCRIPTION
Tested on 10.15.7 with Python 3.6 and 12.0.1 (in a VM) with Python 3.8.

Without this patch, throws the following errors:
* `macos/discovery.py`: "ImportError: cannot import name 'IOBluetoothDeviceInquiry'"
IOBluetoothDeviceInquiry is not in Foundation, but in IOBluetooth, which it seems a bridge has already been formed for, so I just used that.

* `macos/__init__.py`: "AttributeError: module 'bluetooth' has no attribute 'macos'"
`from . import discovery as discovery` would have also worked.  Not sure why the in-tree import did not work, but this is apparently the correct formation.

Current release does not seem to work with Python 3.6 or 3.9 on High Sierra (10.13.6) as it segfaults (11) even without this patch, probably pyObjC related.