### PR TITLE
L2CAP Fix (Tuple -> Number)

### DIFF
--- a/bluetooth/native_socket.py
+++ b/bluetooth/native_socket.py
@@ -8,7 +8,7 @@ protocols =  {
 }
 
 if not sys.platform.startswith("win"):
-    protocols[Protocols.L2CAP] = socket.BTPROTO_L2CAP,
+    protocols[Protocols.L2CAP] = socket.BTPROTO_L2CAP
 
 
 class BluetoothSocket(socket.socket):


### PR DESCRIPTION
Unnecessary comma in protocol definition converts the L2CAP socket information into a tuple.    This results in a bug when trying to instantiate an L2CAP Socket.

Example:
```python
    bluetooth_socket = bluetooth.BluetoothSocket(Protocols.L2CAP)
```
would lead to
```bash
  File "/home/jawaad/PycharmProjects/pythonProject2/main.py", line 48, in <module>
    bluetooth_socket = bluetooth.BluetoothSocket(Protocols.L2CAP)
  File "/home/jawaad/PycharmProjects/pythonProject2/venv/lib/python3.8/site-packages/bluetooth/native_socket.py", line 18, in __init__
    super().__init__ (socket.AF_BLUETOOTH, socket.SOCK_STREAM, _proto)
  File "/usr/lib/python3.8/socket.py", line 231, in __init__
    _socket.socket.__init__(self, family, type, proto, fileno)
TypeError: an integer is required (got type tuple)
```
