### PR TITLE
Replace Py_TYPE(obj)=type with Py_SET_TYPE()

### DIFF
--- a/bluetooth/linux/bluez/btmodule.c
+++ b/bluetooth/linux/bluez/btmodule.c
@@ -3038,8 +3038,8 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__bluetooth(void)
 {
-    Py_TYPE(&sock_type) = &PyType_Type;
-    Py_TYPE(&sdp_session_type) = &PyType_Type;
+    Py_SET_TYPE(&sock_type, &PyType_Type);
+    Py_SET_TYPE(&sdp_session_type, &PyType_Type);
     PyObject *m = PyModule_Create(&moduledef);
     if (m == NULL)
         INITERROR;


### PR DESCRIPTION
Since Py_TYPE() was changed to an inline static function in PEP670, `Py_TYPE(obj) = new_type` must be replaced with the new function `Py_SET_TYPE(obj, new_type)`, available since Python 3.9. For backward compatibility, this macro can be used:
````c++
#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
static inline void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
{ ob->ob_type = type; }
#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
#endif
````
See https://github.com/python/cpython/issues/83754